### PR TITLE
Rename cfg-master to cfg-generics

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/gilt.yml
+++ b/cfg-{{cookiecutter.project_name}}/gilt.yml
@@ -1,5 +1,5 @@
 ---
-- git: https://github.com/osism/cfg-master.git
+- git: https://github.com/osism/cfg-generics.git
   version: master
   files:
     - src: gilt.yml


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>