### PR TITLE
inventory: by default place storage service on the control nodes

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/inventory/20-roles
+++ b/cfg-{{cookiecutter.project_name}}/inventory/20-roles
@@ -16,10 +16,6 @@ compute01.{{cookiecutter.domain}}
 [network:children]
 control
 
-# NOTE: Group for storage services like Cinder. Not for Ceph.
-[storage:children]
-control
-
 [ceph-control]
 control01.{{cookiecutter.domain}}
 

--- a/cfg-{{cookiecutter.project_name}}/inventory/50-kolla
+++ b/cfg-{{cookiecutter.project_name}}/inventory/50-kolla
@@ -7,6 +7,9 @@
 # NOTE: only required when using Neutron DVR
 [external-compute]
 
+[storage:children]
+control
+
 [common:children]
 control
 network


### PR DESCRIPTION
Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>