### PR TITLE
Remove debops parameters

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
@@ -1,16 +1,5 @@
 ---
 ##########################
-# debops
-
-# apt
-
-apt__enabled: no
-
-# grub
-
-grub_hidden_timeout: False
-
-##########################
 # configuration
 
 configuration_directory: /opt/configuration


### PR DESCRIPTION
Moved to the defaults of osism.ansible.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>