### PR TITLE
Remove network interfaces parameters

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
@@ -89,12 +89,6 @@ operator_authorized_keys:
 {%- endraw %}
 
 ##########################
-# network-interfaces
-
-network_allow_service_restart: no
-network_restart_method: nothing
-
-##########################
 # proxy
 
 proxy_proxies: {}


### PR DESCRIPTION
Moved to the defaults of osism.ansible.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>