### PR TITLE
Remove timezone parameter

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
@@ -69,11 +69,6 @@ sysdig_configure_repository: yes
 zabbix_agent_configure_repository: yes
 
 ##########################
-# timezone
-
-timezone_zone: UTC
-
-##########################
 # operator
 
 operator_user: dragon


### PR DESCRIPTION
Moved to the defaults of osism.ansible.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>