### PR TITLE
Remove operator parameters

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
@@ -46,9 +46,6 @@ repository_version: {{cookiecutter.repository_version}}
 ##########################
 # operator
 
-operator_user: dragon
-operator_group: dragon
-
 # yamllint disable rule:line-length
 operator_public_key: FIXME
 # yamllint enable rule:line-length


### PR DESCRIPTION
Moved to the defaults of osism.ansible.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>