### PR TITLE
Increase Neutron rpc response timeout

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/kolla/files/overlays/neutron.conf
+++ b/cfg-{{cookiecutter.project_name}}/environments/kolla/files/overlays/neutron.conf
@@ -1,6 +1,10 @@
 [DEFAULT]
 dns_domain = {{cookiecutter.domain}}.
 
+# Increase pool size and timeout to prevent missing ovs flow table entries
+rpc_response_timeout = 600
+rpc_conn_pool_size = 120
+
 {%- raw %}
 [placement]
 auth_type = password


### PR DESCRIPTION
  The default timeout can lead to ovs flow table entries not
  getting properly set.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>