### PR TITLE
Remove proxy_proxies parameter

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/cfg-{{cookiecutter.project_name}}/environments/configuration.yml
@@ -84,11 +84,6 @@ cleanup_services_extra:
   - ntp
 
 ##########################
-# proxy
-
-proxy_proxies: {}
-
-##########################
 # kolla
 
 kolla_internal_vip_address: {{cookiecutter.ip_internal}}


### PR DESCRIPTION
{} is the new default of proxy_proxies in osism.commons.proxy.

Signed-off-by: Christian Berendt <berendt@betacloud-solutions.de>