### PR TITLE
Remove Ceph dashboard related variables

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/ceph/configuration.yml
+++ b/cfg-{{cookiecutter.project_name}}/environments/ceph/configuration.yml
@@ -166,8 +166,6 @@ openstack_keys:
 ##########################
 # manager
 
-dashboard_protocol: http
-
 ceph_mgr_modules:
   - balancer
   - dashboard

--- a/cfg-{{cookiecutter.project_name}}/environments/ceph/secrets.yml
+++ b/cfg-{{cookiecutter.project_name}}/environments/ceph/secrets.yml
@@ -2,5 +2,3 @@
 # Dummy variable to avoid error because ansible does not recognize the
 # file as a good configuration file when no variable in it.
 dummy:
-
-dashboard_admin_password: FIXME


### PR DESCRIPTION
Ceph dashboard needs to be deployed via the dashboard.yml playbook.
This involves deploying Grafana and Prometheus as well. Which would be
redundant to the Grafana/Prometheus deployment from kolla-ansible.

Enabling the dashboard is still simple todo via ceph-client. This
is described in the osism documentation.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>