### PR TITLE
kolla: use nova as nova ceph user

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/kolla/configuration.yml
+++ b/cfg-{{cookiecutter.project_name}}/environments/kolla/configuration.yml
@@ -96,9 +96,11 @@ gnocchi_backend_storage: "ceph"
 nova_backend_ceph: "yes"
 
 ceph_gnocchi_pool_name: "metrics"
-ceph_nova_keyring: ceph.client.nova.keyring
 cinder_backup_driver: "ceph"
 glance_backend_file: "no"
+
+ceph_nova_user: nova
+ceph_nova_keyring: ceph.client.nova.keyring
 
 # NOTE: public_network from environments/ceph/configuration.yml
 ceph_public_network: {{cookiecutter.ceph_network_frontend}}


### PR DESCRIPTION
The upstream default has changed from nova to cinder.
We will stay with nova for now.

Signed-off-by: Christian Berendt <berendt@osism.tech>