### PR TITLE
Fix haproxy http-check for Ceph dashboard

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/kolla/files/overlays/haproxy/services.d/haproxy.cfg
+++ b/cfg-{{cookiecutter.project_name}}/environments/kolla/files/overlays/haproxy/services.d/haproxy.cfg
@@ -3,7 +3,7 @@
 
 listen ceph_dashboard
   option httpchk
-  http-check expect status 200
+  http-check expect ! rstatus ^5
   bind {{ kolla_internal_vip_address }}:8140
 {% for host in groups['ceph-mgr'] %}
   server {{ hostvars[host]['ansible_hostname'] }} {{ hostvars[host]['ansible_' + hostvars[host]['storage_interface']]['ipv4']['address'] }}:8080 check inter 2000 rise 2 fall 5


### PR DESCRIPTION
The Ceph dashboard is only ever active on one monitor. The other
monitors will redirect to the active one. Therefore a status 200 check
is only green for the active monitor.

Change the http-check to mark backup monitors as failed, only if the
status code is within 500.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>