### PR TITLE
kolla: remove xtrabackup section from galera.cnf

### DIFF
--- a/cfg-{{cookiecutter.project_name}}/environments/kolla/files/overlays/galera.cnf
+++ b/cfg-{{cookiecutter.project_name}}/environments/kolla/files/overlays/galera.cnf
@@ -1,8 +1,2 @@
-{%- raw -%}
 [mysqld]
 expire_logs_days = 14
-
-[xtrabackup]
-password = {{ database_password }}
-user = root
-{%- endraw %}


### PR DESCRIPTION
This is a leftover from the past and is no longer needed today.

Signed-off-by: Christian Berendt <berendt@osism.tech>