### PR TITLE
Fix operator_public_key in manager/configuration.yml

### DIFF
--- a/{{cookiecutter.project_name}}/scripts/set-ssh-keypairs.py
+++ b/{{cookiecutter.project_name}}/scripts/set-ssh-keypairs.py
@@ -45,6 +45,7 @@ with open("secrets/id_rsa.operator.pub", 'r') as fp:
     data = fp.read()
     data = data.rstrip()
 configuration['operator_public_key'] = data
+configuration_manager['operator_public_key'] = data
 
 # set configuration public key
 


### PR DESCRIPTION
add "configuration_manager['operator_public_key'] = data" in "{{cookiecutter.project_name}}/scripts/set-ssh-keypairs.py"

to fix following failed messages:

```
TASK [osism.commons.operator : Set ssh authorized keys] *************************************************************************************************************************************************************************************************************************************
failed: [192.168.122.11] (item=None) => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
fatal: [192.168.122.11]: FAILED! => {"censored": "the output has been hidden due to the fact that 'no_log: true' was specified for this result", "changed": false}
```
Because the manager/configuration.yml was created with:
```
# yamllint disable rule:line-length
operator_public_key: FIXME
# yamllint enable rule:line-length
```