### PR TITLE
Remove docker_registry parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,6 @@ ceph_network_backend [192.168.80.0/20]:
     <td><code>pacific</code></td>
   </tr>
   <tr>
-    <td><code>docker_registry</code></td>
-    <td>Registry used by docker to fetch containers</td>
-    <td><code>quay.io</code></td>
-  </tr>
-  <tr>
     <td><code>docker_version</code></td>
     <td>The version of the Docker service. The <code>5:</code> prefix must be prepended starting with version 18.09.</td>
     <td><code>5:20.10.13</code></td>

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,6 @@
     "ceph_network_backend": "192.168.80.0/20",
     "ceph_network_frontend": "192.168.64.0/20",
     "ceph_version": "pacific",
-    "docker_registry": "quay.io",
     "docker_version": "5:20.10.13",
     "domain": "osism.xyz",
     "fqdn_external": "api.osism.xyz",

--- a/{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/configuration.yml
@@ -8,16 +8,10 @@ docker_version: "{{cookiecutter.docker_version}}"
 docker_user: "{{ operator_user }}"
 {%- endraw %}
 
-# docker_configure_insecure_registries: true
-# docker_insecure_registries:
-#   - {{cookiecutter.docker_registry}}
-
 {%- if cookiecutter.with_ceph|int %}
-ceph_docker_registry: {{cookiecutter.docker_registry}}
+ceph_docker_registry: quay.io
 {%- endif %}
 docker_registry: index.docker.io
-docker_registry_ansible: {{cookiecutter.docker_registry}}
-docker_registry_service: {{cookiecutter.docker_registry}}
 
 ##########################
 # operator

--- a/{{cookiecutter.project_name}}/environments/kolla/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/kolla/configuration.yml
@@ -2,7 +2,7 @@
 ##########################################################
 # images
 
-docker_registry: {{cookiecutter.docker_registry}}
+docker_registry: quay.io
 
 ##########################################################
 # haproxy


### PR DESCRIPTION
Since we use different (historically grown) docker_registry parameters,
it is not possible to switch to a single internal registry through a
single parameter in the cookiecutter.

Therefore, the docker_registry parameter is removed and the documentation
lists how to convert from public registries to a single internal registry.

Closes #321

Signed-off-by: Christian Berendt <berendt@osism.tech>