### PR TITLE
kolla: remove enable_grafana

### DIFF
--- a/{{cookiecutter.project_name}}/environments/kolla/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/kolla/configuration.yml
@@ -17,7 +17,6 @@ kolla_external_fqdn: {{cookiecutter.fqdn_external}}
 
 # enable services
 enable_designate: "yes"
-enable_grafana: "yes"
 enable_octavia: "yes"
 
 # disable services


### PR DESCRIPTION
It is set to yes by default via ansible-defaults.

Signed-off-by: Christian Berendt <berendt@osism.tech>