### PR TITLE
Remove tmp-from-image-mirror from .gitignore

### DIFF
--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -5,4 +5,3 @@ id_rsa.operator
 roles
 secrets
 secure.yml
-tmp-from-image-mirror


### PR DESCRIPTION
Has not been used for a long time.

Signed-off-by: Christian Berendt <berendt@osism.tech>