### PR TITLE
Remove docker_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,11 +96,6 @@ ceph_network_backend [192.168.80.0/20]:
     <td><code>pacific</code></td>
   </tr>
   <tr>
-    <td><code>docker_version</code></td>
-    <td>The version of the Docker service. The <code>5:</code> prefix must be prepended starting with version 18.09.</td>
-    <td><code>5:20.10.17</code></td>
-  </tr>
-  <tr>
     <td><code>domain</code></td>
     <td>The Domain</td>
     <td><code>osism.xyz</code></td>

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,7 +6,6 @@
     "ceph_network_backend": "192.168.80.0/20",
     "ceph_network_frontend": "192.168.64.0/20",
     "ceph_version": "pacific",
-    "docker_version": "5:20.10.17",
     "domain": "osism.xyz",
     "fqdn_external": "api.osism.xyz",
     "fqdn_internal": "api-int.osism.xyz",

--- a/{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/configuration.yml
@@ -2,7 +2,6 @@
 ##########################
 # docker
 
-docker_version: "{{cookiecutter.docker_version}}"
 {% raw -%}
 docker_user: "{{ operator_user }}"
 {%- endraw %}


### PR DESCRIPTION
docker_version is part of the osism.services defaults &
the osism-ansible container image.

Signed-off-by: Christian Berendt <berendt@osism.tech>