### PR TITLE
Remove ceph_share_directory

### DIFF
--- a/{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/configuration.yml
@@ -56,6 +56,5 @@ chrony_allowed_subnets:
 ##########################
 # ceph
 
-ceph_share_directory: /share
 ceph_cluster_fsid: {{cookiecutter.ceph_fsid}}
 {%- endif %}


### PR DESCRIPTION
Now part of the defaults.

Signed-off-by: Christian Berendt <berendt@osism.tech>