### PR TITLE
kolla: remove enable_neutron_qos

### DIFF
--- a/{{cookiecutter.project_name}}/environments/kolla/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/kolla/configuration.yml
@@ -33,7 +33,6 @@ es_heap_size: "4g"
 neutron_plugin_agent: "openvswitch"
 
 enable_neutron_agent_ha: "yes"
-enable_neutron_qos: "yes"
 
 # octavia
 octavia_network_type: tenant


### PR DESCRIPTION
enable_neutron_qos is true by default via osism/ansible-defaults.

Signed-off-by: Christian Berendt <berendt@osism.tech>