### PR TITLE
Add ironic-agent.{kernel,initramfs} to the .gitignore

### DIFF
--- a/{{cookiecutter.project_name}}/.gitignore
+++ b/{{cookiecutter.project_name}}/.gitignore
@@ -1,7 +1,9 @@
-.venv
 *.swp
+.venv
 Pipfile.lock
 id_rsa.operator
+ironic-agent.initramfs
+ironic-agent.kernel
 roles
 secrets
 secure.yml


### PR DESCRIPTION
These two files are expected by the Ironic role in the configuration repository. However, they are stored there beforehand. Therefore, they do not need to be added to the repository by commit.

Signed-off-by: Christian Berendt <berendt@osism.tech>