### PR TITLE
Do net set ceph_version/openstack_version when manager_version != latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ ceph_network_backend [192.168.80.0/20]:
   </tr>
   <tr>
     <td><code>ceph_version</code></td>
-    <td>The version of Ceph</td>
+    <td>The version of Ceph. When using a stable OSISM release (<code>manager_version != latest</code>), this value is ignored.</td>
     <td><code>pacific</code></td>
   </tr>
   <tr>
@@ -134,12 +134,12 @@ ceph_network_backend [192.168.80.0/20]:
   </tr>
   <tr>
     <td><code>ip_internal</code></td>
-    <td>the internal ip address of the API</td>
+    <td>The internal ip address of the API</td>
     <td><code>192.168.32.9</code></td>
   </tr>
   <tr>
     <td><code>manager_version</code></td>
-    <td>The version of the osism-ansible container</td>
+    <td>The version of OSISM. An overview of available OSISM releases can be found on <a href="https://release.osism.tech">release.osism.tech</a>.</td>
     <td><code>latest</code></td>
   </tr>
   <tr>
@@ -154,7 +154,7 @@ ceph_network_backend [192.168.80.0/20]:
   </tr>
   <tr>
     <td><code>openstack_version</code></td>
-    <td>The version of OpenStack</td>
+    <td>The version of OpenStack. When using a stable OSISM release (<code>manager_version != latest</code>), this value is ignored.</td>
     <td><code>yoga</code></td>
   </tr>
   <tr>

--- a/{{cookiecutter.project_name}}/environments/manager/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/manager/configuration.yml
@@ -9,11 +9,13 @@ docker_registry_service: index.docker.io
 ##########################
 # versions
 
+manager_version: {{cookiecutter.manager_version}}
+{% if cookiecutter.manager_version == "latest" %}
 {% if cookiecutter.with_ceph|int -%}
 ceph_version: {{cookiecutter.ceph_version}}
 {% endif -%}
-manager_version: {{cookiecutter.manager_version}}
 openstack_version: {{cookiecutter.openstack_version}}
+{%- endif %}
 
 {% if not cookiecutter.with_ceph|int -%}
 ##########################


### PR DESCRIPTION
If openstack_version or ceph_version are set in environments/manager/configuration.yml, they must be removed when using a stable release

Signed-off-by: Christian Berendt <berendt@osism.tech>