### PR TITLE
Use hosts_type = local

### DIFF
--- a/{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/configuration.yml
@@ -30,7 +30,7 @@ resolvconf_search: {{cookiecutter.domain}}
 ##########################
 # hosts
 
-hosts_type: template
+hosts_type: local
 hosts_additional_entries:
   {{cookiecutter.fqdn_internal}}: {{cookiecutter.ip_internal}}
 {%- if cookiecutter.fqdn_external != cookiecutter.fqdn_internal %}


### PR DESCRIPTION
With the local approach to generating the /etc/hosts file, the file is only generated once and then copied. This is sufficient in most cases.

If different /etc/hosts files are needed on different host groups, it is necessary to switch back to template.

Signed-off-by: Christian Berendt <berendt@osism.tech>