### PR TITLE
Fix for rabbitmq_password reference

### DIFF
--- a/{{cookiecutter.project_name}}/scripts/set-secrets.py
+++ b/{{cookiecutter.project_name}}/scripts/set-secrets.py
@@ -82,7 +82,7 @@ netbox_api_token = "".join(
     [random.SystemRandom().choice(string.digits) for n in range(40)]
 )
 secrets_output_manager["netbox_api_token"] = netbox_api_token
-secrets_output_manager["manager_listener_broker_password"] = SECRETSFILE_INPUT_KOLLA["rabbitmq_password"]
+secrets_output_manager["manager_listener_broker_password"] = secrets_input["rabbitmq_password"]
 
 secrets_output_infrastructure["netbox_user_api_token"] = netbox_api_token
 secrets_output_infrastructure["netbox_secret_key"] = "".join(


### PR DESCRIPTION
mixup with filename (SECRETSFILE_INPUT_KOLLA) and dict holding the secrets (secrets_input) - fixed