### PR TITLE
nova-compute: set sane defaults

### DIFF
--- a/{{cookiecutter.project_name}}/environments/kolla/files/overlays/nova/nova-compute.conf
+++ b/{{cookiecutter.project_name}}/environments/kolla/files/overlays/nova/nova-compute.conf
@@ -1,5 +1,7 @@
 [DEFAULT]
 vif_plugging_is_fatal = false
+resume_guests_state_on_host_boot = true
+enable_new_services = false
 {%- if cookiecutter.with_ceph|int %}
 
 [libvirt]


### PR DESCRIPTION
Sadly nova has defaults for some configuration options that do not make too much sense from an operations perspective. Override them in our template:

- Guest instances should be resumed after a hypervisor reboot
- New compute services should not be enabled by default

Closes osism/issues#548
Signed-off-by: Dr. Jens Harbott <harbott@osism.tech>