### PR TITLE
Add stdout_callback to ansible.cfg

### DIFF
--- a/{{cookiecutter.project_name}}/environments/ansible.cfg
+++ b/{{cookiecutter.project_name}}/environments/ansible.cfg
@@ -12,6 +12,8 @@ deprecation_warnings = false
 # use -vvvv to see details" warning message
 force_valid_group_names = ignore
 
+stdout_callback = community.general.yaml
+
 host_key_checking = false
 
 # hide paramiko transport logging messages


### PR DESCRIPTION
Add stdout_callback configuration to use community.general.yaml as the callback plugin for stdout.

Before:

ok: [testbed-node-0.testbed.osism.xyz] => {"changed": false, "checksum":
"7e4517428bb50b8211d986d924d2c47f41e41527", "dest": "/etc/hosts", "gid":
0, "group": "root", "mode": "0644", "owner": "root", "path": "/etc/hosts",
"size": 758, "state": "file", "uid": 0}

After:

ok: [testbed-node-0.testbed.osism.xyz] => changed=false
  checksum: 7e4517428bb50b8211d986d924d2c47f41e41527
  dest: /etc/hosts
  gid: 0
  group: root
  mode: '0644'
  owner: root
  path: /etc/hosts
  size: 758
  state: file
  uid: 0

Thanks to https://twitter.com/lopez.