### PR TITLE
zuul: fix ansible-lint job

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,13 +1,13 @@
 ---
 exclude_paths:
-  - ./{{cookiecutter.project_name}}/environments/openstack/configuration.yml
-  - ./{{cookiecutter.project_name}}/environments/ceph/configuration.yml
-  - ./{{cookiecutter.project_name}}/environments/manager/configuration.yml
-  - ./{{cookiecutter.project_name}}/environments/kolla/configuration.yml
-  - ./{{cookiecutter.project_name}}/environments/configuration.yml
-  - ./{{cookiecutter.project_name}}/environments/generic/configuration.yml
-  - ./{{cookiecutter.project_name}}/environments/monitoring/configuration.yml
-  - ./{{cookiecutter.project_name}}/environments/infrastructure/configuration.yml
-  - ./{{cookiecutter.project_name}}/environments/custom/configuration.yml
+  - \{\{cookiecutter.project_name\}\}/environments/openstack/configuration.yml
+  - \{\{cookiecutter.project_name\}\}/environments/ceph/configuration.yml
+  - \{\{cookiecutter.project_name\}\}/environments/manager/configuration.yml
+  - \{\{cookiecutter.project_name\}\}/environments/kolla/configuration.yml
+  - \{\{cookiecutter.project_name\}\}/environments/configuration.yml
+  - \{\{cookiecutter.project_name\}\}/environments/generic/configuration.yml
+  - \{\{cookiecutter.project_name\}\}/environments/monitoring/configuration.yml
+  - \{\{cookiecutter.project_name\}\}/environments/infrastructure/configuration.yml
+  - \{\{cookiecutter.project_name\}\}/environments/custom/configuration.yml
 mock_roles:
   - ensure-docker


### PR DESCRIPTION
After switching to merging .ansible-lint with defaults, this file is treated as a Jinja2 template.