### PR TITLE
Use a single network for ceph frontend & backend

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,8 +1,7 @@
 {
     "with_ceph": 1,
     "with_keycloak": 0,
-    "ceph_network_backend": "192.168.80.0/20",
-    "ceph_network_frontend": "192.168.64.0/20",
+    "ceph_network": "192.168.64.0/20",
     "ceph_version": "quincy",
     "domain": "osism.xyz",
     "fqdn_external": "api.osism.xyz",

--- a/cookiecutter.yml.sample
+++ b/cookiecutter.yml.sample
@@ -1,7 +1,6 @@
 ---
 default_context:
-  ceph_network_backend:
-  ceph_network_frontend:
+  ceph_network:
   domain:
   fqdn_external:
   fqdn_internal:

--- a/{{cookiecutter.project_name}}/environments/ceph/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/ceph/configuration.yml
@@ -7,8 +7,8 @@ fsid:
 ##########################
 # network
 
-public_network: {{cookiecutter.ceph_network_frontend}}
-cluster_network: {{cookiecutter.ceph_network_backend}}
+public_network: {{cookiecutter.ceph_network}}
+cluster_network: {{cookiecutter.ceph_network}}
 
 ##########################
 # custom

--- a/{{cookiecutter.project_name}}/environments/kolla/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/kolla/configuration.yml
@@ -66,7 +66,7 @@ ceph_nova_user: nova
 ceph_nova_keyring: ceph.client.nova.keyring
 
 # NOTE: public_network from environments/ceph/configuration.yml
-ceph_public_network: {{cookiecutter.ceph_network_frontend}}
+ceph_public_network: {{cookiecutter.ceph_network}}
 {%- endif %}
 
 {%- if cookiecutter.with_keycloak|int %}


### PR DESCRIPTION
This does not need to be adapted for existing deployments. But we currently only use a single network for Ceph by default on new deployments. The cluster network can still be customised after the initial configuration has been created.