### PR TITLE
manager: do not enable the listener service by default

### DIFF
--- a/{{cookiecutter.project_name}}/environments/manager/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/manager/configuration.yml
@@ -32,22 +32,6 @@ ara_enable: true
 ara_server_host: "{{ hostvars[inventory_hostname]['ansible_' + internal_interface]['ipv4']['address'] }}"
 
 ##########################
-# listener
-
-# FIXME: It does not work here to work with inventory groups because
-#        the manager's inventory is independent from the rest of the
-#        inventory.
-#
-#        For manager_listener_broker_hosts, a list of IP addresses or
-#        hostnames must be set up on which the RabbitMQ Broker can be
-#        reached on the control nodes.
-
-enable_listener: true
-manager_listener_broker_hosts: []
-manager_listener_broker_username: openstack
-manager_listener_broker_uri: "{% for host in manager_listener_broker_hosts %}amqp://{{ manager_listener_broker_username }}:{{ manager_listener_broker_password }}@{{ host }}:5672/{% if not loop.last %};{% endif %}{% endfor %}"
-
-##########################
 # netbox
 
 netbox_enable: true

--- a/{{cookiecutter.project_name}}/environments/manager/secrets.yml
+++ b/{{cookiecutter.project_name}}/environments/manager/secrets.yml
@@ -3,8 +3,3 @@
 # netbox integration
 
 netbox_api_token:
-
-##########################
-# rabbitmq integration
-
-manager_listener_broker_password:


### PR DESCRIPTION
The listener service is only needed when working with Ironic. This is not the case everywhere. It is documented accordingly how the listener service is to be used when Ironic is used.

Related to osism/issues#967