### PR TITLE
Set docker_version

### DIFF
--- a/{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/configuration.yml
@@ -2,6 +2,7 @@
 ##########################
 # docker
 
+docker_version: "5:24.0.9"
 {% raw -%}
 docker_user: "{{ operator_user }}"
 {%- endraw %}


### PR DESCRIPTION
It is now possible to automatically synchronise the docker_version in the configuration repository against osism/release. It therefore makes sense to set it explicitly again.