### PR TITLE
Improve haproxy and ceph dashboard integration

### DIFF
--- a/{{cookiecutter.project_name}}/environments/kolla/files/overlays/haproxy/services.d/{{ 'ceph_dashboard.cfg' if cookiecutter.with_ceph|int }}
+++ b/{{cookiecutter.project_name}}/environments/kolla/files/overlays/haproxy/services.d/{{ 'ceph_dashboard.cfg' if cookiecutter.with_ceph|int }}
@@ -1,0 +1,12 @@
+{%- raw -%}
+{%- set internal_tls_bind_info = 'ssl crt /etc/haproxy/certificates/haproxy-internal.pem' if kolla_enable_tls_internal|bool else '' -%}
+
+listen ceph_dashboard
+  option httpchk
+  http-check expect status 200,404
+  http-check disable-on-404
+  {{ "bind %s:%s %s"|format(kolla_internal_vip_address, 8140, internal_tls_bind_info)|trim() }}
+{% for host in groups['ceph-mgr'] %}
+  server {{ hostvars[host]['ansible_facts']['hostname'] }} {{ hostvars[host]['monitor_address'] }}:7000 check inter 2000 rise 2 fall 5
+{% endfor %}
+{%- endraw -%}


### PR DESCRIPTION
Passive ceph mgr are configured to emit an error with status code 404 for ceph dashboard.
Haproxy is configured to treat status 404 as server state "NOLB" instead of marking servers as "DOWN".
The clear separation between a passive server with state "NOLB" and a malfunctioning server with state "DOWN" will allow more differentiated alerting on haproxy server states.

Part of https://github.com/osism/issues/issues/1013