### PR TITLE
Fix argument to find -type

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -58,7 +58,7 @@ if [[ {{ cookiecutter.with_keycloak }} == 0 ]]; then
     rm -rf environments/kolla/files/overlays/keystone
 fi
 
-for script in $(find scripts.d -type file -perm -111 -print); do
+for script in $(find scripts.d -type f -perm -111 -print); do
     echo run additional script $script
     $script
 done


### PR DESCRIPTION
At least POSIX and GNU find only support shorthands as arguments to `find` ([1]):

```
find: invalid argument 'file' to '-type'
```

[1]
https://www.gnu.org/software/findutils/manual/html_mono/find.html#Type https://pubs.opengroup.org/onlinepubs/9699919799/utilities/find.html