### PR TITLE
Remove chrony_allowed_subnets parameter

### DIFF
--- a/{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/configuration.yml
@@ -42,8 +42,6 @@ hosts_additional_entries:
 
 chrony_servers:
   - {{cookiecutter.ntp_server}}
-chrony_allowed_subnets:
-  - 127.0.0.1/32
 {%- if cookiecutter.with_ceph|int %}
 
 ##########################


### PR DESCRIPTION
The chrony_allowed_subnets is part of the osism/defaults.