### PR TITLE
Remove neutron/ml2_conf.ini file to avoid confusion

### DIFF
--- a/{{cookiecutter.project_name}}/environments/kolla/files/overlays/neutron/ml2_conf.ini
+++ b/{{cookiecutter.project_name}}/environments/kolla/files/overlays/neutron/ml2_conf.ini
@@ -1,2 +1,0 @@
-# [ml2_type_vlan]
-# network_vlan_ranges = {% for bridge in neutron_bridge_name.split(',') %}physnet{{ loop.index0 + 1 }}{% if not loop.last %},{% endif %}{% endfor %}


### PR DESCRIPTION
This is only necessary when working with multiple provider VLANs. This should be documented in the configuration guide.