### PR TITLE
Add admin-system cloud definition

### DIFF
--- a/{{cookiecutter.project_name}}/environments/openstack/clouds.yml
+++ b/{{cookiecutter.project_name}}/environments/openstack/clouds.yml
@@ -8,6 +8,13 @@ clouds:
       project_domain_name: default
       user_domain_name: default
     endpoint_type: internalURL
+  admin-system:
+    auth:
+      username: admin
+      auth_url: https://{{cookiecutter.fqdn_internal}}:5000/v3
+      user_domain_name: default
+      system_scope: all
+    endpoint_type: internalURL
   octavia:
     auth:
       username: octavia

--- a/{{cookiecutter.project_name}}/environments/openstack/secure.yml.sample
+++ b/{{cookiecutter.project_name}}/environments/openstack/secure.yml.sample
@@ -3,6 +3,9 @@ clouds:
   admin:
     auth:
       password: password
+  admin-system:
+    auth:
+      password: password
   octavia:
     auth:
       password: password


### PR DESCRIPTION
Interacting with the ironic service requires using system-scope, add a cloud definition that allows this, cf. [0].

[0] https://review.opendev.org/c/openstack/kolla-ansible/+/908168