### PR TITLE
Fix RGW keystone integration

### DIFF
--- a/{{cookiecutter.project_name}}/environments/ceph/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/ceph/configuration.yml
@@ -19,7 +19,7 @@ ceph_conf_overrides:
     osd pool default size: 3
   mon:
     mon allow pool delete: true
-  "client.rgw.{% raw %}{{ hostvars[inventory_hostname]['ansible_hostname'] }}{% endraw %}.rgw0":
+  "client.rgw.{% raw %}{{ rgw_zone }}.{{ hostvars[inventory_hostname]['ansible_hostname'] }}{% endraw %}.rgw0":
     "rgw content length compat": "true"
     "rgw enable apis": "swift, s3, admin"
     "rgw keystone accepted admin roles": "admin"


### PR DESCRIPTION
The RGW zone has been added to the radosgw name in [1].

[1]
https://github.com/ceph/ceph-ansible/commit/faae48d75b9f5386dea2f877282a9649ab3941a3