### PR TITLE
fix: correct SSH key generation condition in generate-secrets

### DIFF
--- a/{{cookiecutter.project_name}}/scripts/generate-secrets.py
+++ b/{{cookiecutter.project_name}}/scripts/generate-secrets.py
@@ -73,7 +73,7 @@ def genpwd(
 
     for k, v in passwords.items():
         if k in ssh_keys and (
-            v is None or v.get("public_key") is None and v.get("private_key") is None
+            v is None or v.get("public_key") is None or v.get("private_key") is None
         ):
             private_key, public_key = generate_RSA()
             passwords[k] = {"private_key": private_key, "public_key": public_key}
@@ -138,6 +138,7 @@ def main():
         "haproxy_ssh_key",
         "keystone_ssh_key",
         "kolla_ssh_key",
+        "neutron_ssh_key",
         "nova_ssh_key",
         "octavia_amp_ssh_key",
     ]


### PR DESCRIPTION
The condition used `and` instead of `or` when checking for missing SSH keys, causing key pairs to not be regenerated when only one of public_key/private_key was missing. Also add missing neutron_ssh_key to the ssh_keys list.

AI-assisted: Claude Code