### PR TITLE
Rename repository from cfg-generics -> generics

### DIFF
--- a/{{cookiecutter.project_name}}/gilt.yml
+++ b/{{cookiecutter.project_name}}/gilt.yml
@@ -1,5 +1,5 @@
 ---
-- git: https://github.com/osism/cfg-generics.git
+- git: https://github.com/osism/generics.git
   version: main
   files:
     - src: gilt.yml

--- a/{{cookiecutter.project_name}}/inventory/99-overwrite
+++ b/{{cookiecutter.project_name}}/inventory/99-overwrite
@@ -4,6 +4,6 @@
 # This applies to both the form with :children and without.
 #
 # All predefined and usable inventory groups can be found
-# in the cfg-generics repository.
+# in the generics repository.
 #
-# https://github.com/osism/cfg-generics/tree/main/inventory
+# https://github.com/osism/generics/tree/main/inventory


### PR DESCRIPTION
## Summary
- The `osism/cfg-generics` repository was renamed to `osism/generics`. New customer configs generated from this cookiecutter template should be seeded with the current URL rather than relying on GitHub's rename alias.
- Updates `{{cookiecutter.project_name}}/gilt.yml` and the explanatory comment in `{{cookiecutter.project_name}}/inventory/99-overwrite`.

## Test plan
- [ ] Generate a config with cookiecutter; verify the rendered `gilt.yml` points at `osism/generics`
- [ ] Verify `gilt overlay` runs successfully against the new URL