### PR TITLE
Retire OpenStack 2024.2 Dalmatian

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -66,13 +66,6 @@
         OPENSTACK_VERSION: "2024.1"
 
 - job:
-    name: cfg-cookiecutter-tox-2024.2
-    parent: cfg-cookiecutter-tox
-    vars:
-      tox_environment:
-        OPENSTACK_VERSION: "2024.2"
-
-- job:
     name: cfg-cookiecutter-tox-2025.1
     parent: cfg-cookiecutter-tox
     vars:
@@ -97,7 +90,6 @@
         - python-black
         - yamllint
         - cfg-cookiecutter-tox-2024.1
-        - cfg-cookiecutter-tox-2024.2
         - cfg-cookiecutter-tox-2025.1
         - cfg-cookiecutter-tox-2025.2
         - container-image-cfg-cookiecutter-build


### PR DESCRIPTION
## Summary

OpenStack 2024.2 Dalmatian is a non-SLURP release that reached its
end-of-life deadline on 2026-04-29. The upstream kolla-ansible
`stable/2024.2` branch has been deleted; the release is fully retired.

Remove the `cfg-cookiecutter-tox-2024.2` job definition and its entry
in the check pipeline.

The `2024.1` job is retained: 2024.1 is a SLURP release with a longer
maintenance window and is not yet retired.

Tracks: https://github.com/osism/issues/issues/1367