### PR TITLE
replace deprecated (and removed) ugettext_lazy with gettext_lazy

### DIFF
--- a/{{cookiecutter.project_name}}/environments/kolla/files/overlays/horizon/_9999-custom-settings.py
+++ b/{{cookiecutter.project_name}}/environments/kolla/files/overlays/horizon/_9999-custom-settings.py
@@ -2,7 +2,7 @@
 
 # customer specific configuration
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # SESSION_TIMEOUT = 7200
 # OPENSTACK_ENABLE_PASSWORD_RETRIEVE = True

--- a/{{cookiecutter.project_name}}/environments/kolla/files/overlays/horizon/custom_local_settings
+++ b/{{cookiecutter.project_name}}/environments/kolla/files/overlays/horizon/custom_local_settings
@@ -2,7 +2,7 @@
 
 # customer specific configuration
 
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 # SESSION_TIMEOUT = 7200
 # OPENSTACK_ENABLE_PASSWORD_RETRIEVE = True


### PR DESCRIPTION
* ugettext_lazy was removed in Django 4.0.0 https://docs.djangoproject.com/en/6.0/releases/4.0/#features-removed-in-4-0 and replaced with gettext_lazy https://docs.djangoproject.com/en/3.0/releases/3.0/#features-deprecated-in-3-0
* OpenStack 2024.1 started using Django 4, leading to the import error

fixes: https://github.com/osism/issues/issues/1172