### PR TITLE
Rephrase single-server notes to lead with action

### DIFF
--- a/{{cookiecutter.project_name}}/environments/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/configuration.yml
@@ -24,9 +24,9 @@ operator_authorized_keys:
 ##########################
 # resolvconf
 
-# NOTE: As it is not trivial to comfortably query several entries for a parameter
-#       with Cookiecutter, only one DNS server is added here. At least one additional
-#       DNS server should be added. Delete this comment afterwards.
+# NOTE: Add at least one more DNS server for production deployments. Only one
+#       server is set here due to a Cookiecutter prompting limitation. Delete
+#       this comment afterwards.
 # DOCS: https://osism.tech/docs/guides/configuration-guide/commons/resolvconf
 resolvconf_nameserver:
   - {{cookiecutter.name_server}}
@@ -44,9 +44,9 @@ hosts_additional_entries:
 ##########################
 # chrony
 
-# NOTE: As it is not trivial to comfortably query several entries for a parameter
-#       with Cookiecutter, only one NTP server is added here. At least one additional
-#       NTP server should be added. Delete this comment afterwards.
+# NOTE: Add at least one more NTP server. The chrony role requires a minimum of
+#       two servers and bootstrap fails otherwise. Only one server is set here
+#       due to a Cookiecutter prompting limitation. Delete this comment afterwards.
 # DOCS: https://osism.tech/docs/guides/configuration-guide/services/chrony
 chrony_servers:
   - {{cookiecutter.ntp_server}}


### PR DESCRIPTION
The NOTE comments for `resolvconf_nameserver` and `chrony_servers` in the generated `environments/configuration.yml` led with an explanation of a Cookiecutter limitation (prompts cannot comfortably collect multiple values for one parameter) and only then advised adding more servers. Users skimming the generated configuration could easily miss the required action.

Rephrase both notes to lead with what the user must do and shorten the explanation to a single clause. The two notes are no longer identical because the obligations differ in strength:

- The chrony role fails hard during bootstrap with fewer than two servers (default of `chrony_minimum_number_of_servers`, introduced in osism/ansible-collection-services#1554), so its note now states that consequence explicitly.
- The resolvconf role accepts a single nameserver, so its note frames the addition as required for production deployments.

This is a comment-only change; the generated configuration values are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)