### PR TITLE
Use OSISM 10.0.0 by default

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,7 +12,7 @@
     "git_version": "main",
     "ip_external": "192.168.16.254",
     "ip_internal": "192.168.16.9",
-    "manager_version": "8.1.0",
+    "manager_version": "10.0.0",
     "name_server": "149.112.112.112",
     "ntp_server": "de.pool.ntp.org",
     "openstack_version": "2024.1",


### PR DESCRIPTION
The `manager_version` default has not been updated since OSISM 8.1.0 (#695).
The [documentation](https://osism.tech/docs/guides/configuration-guide/configuration-repository#using-latest) states that the default is always the latest stable release, which is
currently 10.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)