### PR TITLE
chore: remove .vault_pass from environments template

### DIFF
--- a/hooks/post_gen_project.sh
+++ b/hooks/post_gen_project.sh
@@ -29,7 +29,6 @@ chmod 0600 secrets/vaultpass
 for secretsfile in $(find environments -name 'secrets.yml'); do
     ansible-vault encrypt --vault-password-file secrets/vaultpass $secretsfile
 done
-chmod +x environments/.vault_pass
 
 if [[ {{ cookiecutter.with_ceph }} == 0 ]]; then
 

--- a/{{cookiecutter.project_name}}/environments/.vault_pass
+++ b/{{cookiecutter.project_name}}/environments/.vault_pass
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-cat /opt/configuration/secrets/vaultpass


### PR DESCRIPTION
## Summary

Removes the `.vault_pass` file from the cookiecutter `environments` template.

## Changes

- Delete `{{cookiecutter.project_name}}/environments/.vault_pass`

🤖 Generated with [Claude Code](https://claude.com/claude-code)