### PR TITLE
Remove rook environment

### DIFF
--- a/{{cookiecutter.project_name}}/environments/rook/configuration.yml
+++ b/{{cookiecutter.project_name}}/environments/rook/configuration.yml
@@ -1,4 +1,0 @@
----
-# Dummy variable to avoid error because ansible does not recognize the
-# file as a good configuration file when no variable in it.
-dummy:

--- a/{{cookiecutter.project_name}}/environments/rook/images.yml
+++ b/{{cookiecutter.project_name}}/environments/rook/images.yml
@@ -1,4 +1,0 @@
----
-# Dummy variable to avoid error because ansible does not recognize the
-# file as a good configuration file when no variable in it.
-dummy:

--- a/{{cookiecutter.project_name}}/environments/rook/secrets.yml
+++ b/{{cookiecutter.project_name}}/environments/rook/secrets.yml
@@ -1,4 +1,0 @@
----
-# Dummy variable to avoid error because ansible does not recognize the
-# file as a good configuration file when no variable in it.
-dummy:


### PR DESCRIPTION
Rook is no longer offered as an option for deploying Ceph. The generated configuration repository therefore should not include any rook-related configuration or secrets.

This drops the environments/rook directory, which only contained dummy placeholder configuration.yml, images.yml and secrets.yml files and was not referenced anywhere else in the template. Ceph deployment via ceph-ansible (environments/ceph, gated by with_ceph) is unaffected.

Assisted-by: Claude:claude-opus-4-8