### PR TITLE
octavia: use soft anti-affinity for amphorae

### DIFF
--- a/{{cookiecutter.project_name}}/environments/kolla/files/overlays/octavia.conf
+++ b/{{cookiecutter.project_name}}/environments/kolla/files/overlays/octavia.conf
@@ -1,6 +1,6 @@
 [nova]
 enable_anti_affinity = true
-anti_affinity_policy = anti-affinity
+anti_affinity_policy = soft-anti-affinity
 
 [oslo_middleware]
 enable_proxy_headers_parsing = true


### PR DESCRIPTION
## What

Change the default octavia amphora anti-affinity policy from hard `anti-affinity` to `soft-anti-affinity` in the generated Kolla octavia overlay.

```diff
 [nova]
 enable_anti_affinity = true
-anti_affinity_policy = anti-affinity
+anti_affinity_policy = soft-anti-affinity
```

`enable_anti_affinity = true` and `octavia_loadbalancer_topology: ACTIVE_STANDBY` are left unchanged.

## Why

OSISM deploys octavia as ACTIVE_STANDBY, so each load balancer boots two amphorae (MASTER + BACKUP) into a per-LB nova server group. With **hard** anti-affinity the two members must land on distinct compute hosts or the build fails.

On small compute pools — the **production-minimum** OSISM topology is 3 compute hosts converged onto the control nodes — a burst of concurrent LB creates races nova's scheduler: two members can be placed on the same host before either is recorded, and nova's late `_validate_instance_group_policy` re-check then raises `GroupAffinityViolation`, sending the amphora to ERROR and the LB to ERROR. This happens **before** the amphora image is cloned, so it is a scheduler-concurrency + host-count issue, not a storage/IO or timeout one. A realistic production trigger is Kubernetes bringing up several `Service type=LoadBalancer` at once.

`soft-anti-affinity` makes nova still prefer distinct hosts but not fail the build when it cannot — preserving HA-placement intent while removing the hard-failure race.

## Validation

Live on a fresh 3-compute-host OSISM 10.1.0 cluster, A/B with only the policy changed, 8 concurrent LB creates:

- `anti-affinity` (hard): **6 ACTIVE / 2 ERROR**
- `soft-anti-affinity`: **8 ACTIVE / 0 ERROR**

**Bounded downside:** under scheduling pressure an LB's MASTER + BACKUP may co-locate (no HA for that LB until rescheduled) — strictly better than a hard build failure, and only under pressure.

## Follow-up

- tbng's `config.src/environments/kolla/files/overlays/octavia.conf` is byte-identical to this overlay and will pick this up on the next `genconfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)