### PR TITLE
Add OpenStack 2026.1

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -79,6 +79,13 @@
       tox_environment:
         OPENSTACK_VERSION: "2025.2"
 
+- job:
+    name: cfg-cookiecutter-tox-2026.1
+    parent: cfg-cookiecutter-tox
+    vars:
+      tox_environment:
+        OPENSTACK_VERSION: "2026.1"
+
 - project:
     merge-mode: squash-merge
     default-branch: main
@@ -92,6 +99,7 @@
         - cfg-cookiecutter-tox-2024.1
         - cfg-cookiecutter-tox-2025.1
         - cfg-cookiecutter-tox-2025.2
+        - cfg-cookiecutter-tox-2026.1
         - container-image-cfg-cookiecutter-build
     periodic-daily:
       jobs:

--- a/{{cookiecutter.project_name}}/environments/kolla/secrets.yml.2026.1
+++ b/{{cookiecutter.project_name}}/environments/kolla/secrets.yml.2026.1
@@ -1,0 +1,236 @@
+---
+###################
+# External Ceph options
+####################
+# These options must be UUID4 values in string format
+# XXXXXXXX-XXXX-4XXX-XXXX-XXXXXXXXXXXX
+# for backward compatible consideration, rbd_secret_uuid is only used for nova,
+# cinder_rbd_secret_uuid is used for cinder
+rbd_secret_uuid:
+cinder_rbd_secret_uuid:
+
+###################
+# Database options
+####################
+database_password:
+# Password for the dedicated backup user account
+mariadb_backup_database_password:
+# Password for the monitor user
+mariadb_monitor_password:
+
+####################
+# Docker options
+####################
+# This should only be set if you require a password for your Docker registry
+docker_registry_password:
+
+#####################
+# Hitachi NAS support
+#####################
+hnas_nfs_password:
+
+#######################
+# Infoblox IPAM support
+#######################
+infoblox_admin_password:
+
+####################
+# OpenStack options
+####################
+aodh_database_password:
+aodh_keystone_password:
+
+barbican_database_password:
+barbican_keystone_password:
+barbican_p11_password:
+barbican_crypto_key:
+
+blazar_database_password:
+blazar_keystone_password:
+
+keystone_admin_password:
+keystone_database_password:
+
+grafana_database_password:
+grafana_admin_password:
+
+glance_database_password:
+glance_keystone_password:
+
+gnocchi_database_password:
+gnocchi_keystone_password:
+
+nova_database_password:
+nova_api_database_password:
+nova_keystone_password:
+
+placement_keystone_password:
+placement_database_password:
+
+neutron_database_password:
+neutron_keystone_password:
+metadata_secret:
+
+cinder_database_password:
+cinder_keystone_password:
+
+cloudkitty_database_password:
+cloudkitty_keystone_password:
+
+cyborg_database_password:
+cyborg_keystone_password:
+
+designate_database_password:
+designate_keystone_password:
+# This option must be UUID4 value in string format
+designate_pool_id:
+# This option must be HMAC-MD5 value in string format
+designate_rndc_key:
+
+heat_database_password:
+heat_keystone_password:
+heat_domain_admin_password:
+
+ironic_database_password:
+ironic_keystone_password:
+
+magnum_database_password:
+magnum_keystone_password:
+
+mistral_database_password:
+mistral_keystone_password:
+
+trove_database_password:
+trove_keystone_password:
+
+ceilometer_database_password:
+ceilometer_keystone_password:
+
+watcher_database_password:
+watcher_keystone_password:
+
+horizon_secret_key:
+horizon_database_password:
+
+telemetry_secret_key:
+
+manila_database_password:
+manila_keystone_password:
+
+octavia_database_password:
+octavia_persistence_database_password:
+octavia_keystone_password:
+octavia_ca_password:
+octavia_client_ca_password:
+
+tacker_database_password:
+tacker_keystone_password:
+
+masakari_database_password:
+masakari_keystone_password:
+
+memcache_secret_key:
+
+skyline_secret_key:
+skyline_database_password:
+skyline_keystone_password:
+
+# HMAC secret key
+osprofiler_secret:
+
+nova_ssh_key:
+  private_key:
+  public_key:
+
+kolla_ssh_key:
+  private_key:
+  public_key:
+
+keystone_ssh_key:
+  private_key:
+  public_key:
+
+bifrost_ssh_key:
+  private_key:
+  public_key:
+
+octavia_amp_ssh_key:
+  private_key:
+  public_key:
+
+neutron_ssh_key:
+  private_key:
+  public_key:
+
+haproxy_ssh_key:
+  private_key:
+  public_key:
+
+####################
+# Gnocchi options
+####################
+gnocchi_project_id:
+gnocchi_resource_id:
+gnocchi_user_id:
+
+####################
+# RabbitMQ options
+####################
+rabbitmq_password:
+rabbitmq_monitoring_password:
+rabbitmq_cluster_cookie:
+
+####################
+# HAProxy options
+####################
+haproxy_password:
+keepalived_password:
+
+####################
+# etcd options
+####################
+etcd_cluster_token:
+
+####################
+# valkey options
+####################
+valkey_master_password:
+# TODO(gkoper): Remove after G/2026.1 release
+redis_master_password:
+
+####################
+# Prometheus options
+####################
+prometheus_mysql_exporter_database_password:
+prometheus_alertmanager_password:
+prometheus_password:
+prometheus_grafana_password:
+prometheus_haproxy_password:
+prometheus_skyline_password:
+prometheus_bcrypt_salt:
+
+###############################
+# OpenStack identity federation
+###############################
+keystone_federation_openid_crypto_password:
+
+####################
+# Ceph RadosGW options
+####################
+ceph_rgw_keystone_password:
+
+##################
+# libvirt options
+##################
+libvirt_sasl_password:
+
+############
+# ProxySQL
+############
+proxysql_admin_password:
+proxysql_stats_password:
+
+############
+# OpenSearch
+############
+opensearch_dashboards_password:


### PR DESCRIPTION
Add the kolla `secrets.yml.2026.1` file, taken verbatim from the `passwords.yml` of the `stable/2026.1` branch of kolla-ansible. Compared to 2025.2 the kuryr and zun passwords are gone.

Add the `cfg-cookiecutter-tox-2026.1` job and run it in the check pipeline.

Related to: https://github.com/osism/issues/issues/1428

🤖 Generated with [Claude Code](https://claude.com/claude-code)