### PR TITLE
Use OSISM 10.2.0, OpenStack 2025.1 and Ceph Reef by default

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,7 +1,7 @@
 {
     "with_ceph": 1,
     "ceph_network": "192.168.16.0/20",
-    "ceph_version": "quincy",
+    "ceph_version": "reef",
     "domain": "osism.xyz",
     "fqdn_external": "api.osism.xyz",
     "fqdn_internal": "api-int.osism.xyz",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,7 +12,7 @@
     "git_version": "main",
     "ip_external": "192.168.16.254",
     "ip_internal": "192.168.16.9",
-    "manager_version": "10.0.0",
+    "manager_version": "10.2.0",
     "name_server": "149.112.112.112",
     "ntp_server": "de.pool.ntp.org",
     "openstack_version": "2024.1",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -15,7 +15,7 @@
     "manager_version": "10.2.0",
     "name_server": "149.112.112.112",
     "ntp_server": "de.pool.ntp.org",
-    "openstack_version": "2024.1",
+    "openstack_version": "2025.1",
     "project_name": "configuration",
     "_copy_without_render": [
         "environments/kolla/files/overlays/keystone/wsgi-keystone.conf",


### PR DESCRIPTION
> **Draft until the 10.2.0 release is complete.** The version directory exists in `osism/release` (`Prepare 10.2.0 release`, 2026-08-13) and every image it pins is available on `registry.osism.tech`, but the release is not announced yet: there are no release notes for it, and one Kolla image (`neutron-metadata-agent`) has no tag for the 20260813 build. Ready for review once the release is out.

The defaults of `cookiecutter.json` had drifted away from what OSISM actually ships. Three commits, one parameter each:

**`Use OSISM 10.2.0 by default`** — the documentation promises that the default is always the latest stable release, and the last time that held was 10.0.0. 10.1.0 (June 2026) was skipped, so a configuration repository created today pins a release two versions behind.

**`Use OpenStack 2025.1 by default`** — the default was still 2024.1. OSISM 10 supports only OpenStack 2025.1 Epoxy, so the default pair asked for a combination OSISM 10 does not ship. The generated repository has a `secrets.yml.2025.1` and `cfg-cookiecutter-tox-2025.1` runs on every change.

**`Use Ceph Reef by default`** — the default was still Quincy. `latest/ceph.yml` in `osism/release` is a symlink to `ceph-reef.yml`, and OSISM 10 ships Ceph 18.2 Reef. The value is only written to `ceph_version` in `environments/manager/configuration.yml`, so no template files depend on it.

Both `openstack_version` and `ceph_version` are ignored while `manager_version != latest`, so those two only affect repositories that switch to `latest` — but the defaults should still describe a combination that exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)